### PR TITLE
Add ECDSA_KEY from dev.yml to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     environment:
       DATABASE_URL: covidshield:covidshield@tcp(mysql)/covidshield
       RETRIEVE_HMAC_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      ECDSA_KEY: 30770201010420a6885a310b694b7bb4ba985459de1e79446dddcd1247c62ece925402b362a110a00a06082a8648ce3d030107a1440342000403eb64f714c4b4ed394331c26c31b7ce7156d00fb28982ad2679a87eaa1a3869802fbeb1d7ee28002762921929c3f7603672d535fcac3d24d57afbb4e2d97f5a
   key-submission:
     build:
       context: .


### PR DESCRIPTION
Partially closes #24 by correcting docker-compose.yml to include a recently added ENV variable.

CovidShield server could still use additional documentation for non-development use cases, perhaps, but it sounds like it's under active development right now. 👍 


Also, that internal "dev up" tool sounds interesting, though if supported, I'd switch the environment variables to an `.env` file or two that docker-compose and dev could both share, that would solve this particular issue. For docker-compose, I believe the syntax is `env_file:` followed by a list of .env files to pull ENV variables from for that container.