### PR TITLE
add cloudfront CDN for retrieval service

### DIFF
--- a/config/terraform/aws/certificates.tf
+++ b/config/terraform/aws/certificates.tf
@@ -12,6 +12,23 @@ resource "aws_acm_certificate" "covidshield" {
   }
 }
 
+###
+# Cloudfront requires client certificate to be created in us-east-1
+###
+resource "aws_acm_certificate" "retrieval_covidshield" {
+  provider          = aws.us-east-1
+  domain_name       = "retrieval.${var.route53_zone_name}"
+  validation_method = "DNS"
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_route53_record" "covidshield_certificate_validation" {
   zone_id = aws_route53_zone.covidshield.zone_id
   name    = aws_acm_certificate.covidshield.domain_validation_options.0.resource_record_name
@@ -20,9 +37,25 @@ resource "aws_route53_record" "covidshield_certificate_validation" {
   ttl     = 60
 }
 
+resource "aws_route53_record" "retrieval_covidshield_certificate_validation" {
+  zone_id = aws_route53_zone.covidshield.zone_id
+  name    = aws_acm_certificate.retrieval_covidshield.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.retrieval_covidshield.domain_validation_options.0.resource_record_type
+  records = [aws_acm_certificate.retrieval_covidshield.domain_validation_options.0.resource_record_value]
+  ttl     = 60
+}
+
 resource "aws_acm_certificate_validation" "covidshield" {
   certificate_arn = aws_acm_certificate.covidshield.arn
   validation_record_fqdns = [
     aws_route53_record.covidshield_certificate_validation.fqdn
+  ]
+}
+
+resource "aws_acm_certificate_validation" "retrieval_covidshield" {
+  provider        = aws.us-east-1
+  certificate_arn = aws_acm_certificate.retrieval_covidshield.arn
+  validation_record_fqdns = [
+    aws_route53_record.retrieval_covidshield_certificate_validation.fqdn
   ]
 }

--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -1,0 +1,54 @@
+###
+# AWS Cloudfront (CDN) - Key Retreval - retrieval.{$route53_zone_name}
+###
+
+resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
+  origin {
+    domain_name = aws_lb.covidshield_key_retrieval.dns_name
+    origin_id   = aws_lb.covidshield_key_retrieval.name
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  enabled         = true
+  is_ipv6_enabled = true
+
+  aliases = ["retrieval.${var.route53_zone_name}"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = aws_lb.covidshield_key_retrieval.name
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    viewer_protocol_policy = "https-only"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 7200
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.retrieval_covidshield.certificate_arn
+    minimum_protocol_version = "TLSv1.2_2018"
+    ssl_support_method       = "sni-only"
+  }
+}

--- a/config/terraform/aws/provider.tf
+++ b/config/terraform/aws/provider.tf
@@ -3,6 +3,12 @@ provider "aws" {
   region  = var.region
 }
 
+provider "aws" {
+  version = "~> 2.0"
+  alias   = "us-east-1"
+  region  = "us-east-1"
+}
+
 provider "github" {
   organization = "CovidShield"
   anonymous    = true

--- a/config/terraform/aws/route53.tf
+++ b/config/terraform/aws/route53.tf
@@ -20,8 +20,8 @@ resource "aws_route53_record" "covidshield_key_retrieval" {
   type    = "A"
 
   alias {
-    name                   = aws_lb.covidshield_key_retrieval.dns_name
-    zone_id                = aws_lb.covidshield_key_retrieval.zone_id
+    name                   = aws_cloudfront_distribution.key_retrieval_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.key_retrieval_distribution.hosted_zone_id
     evaluate_target_health = false
   }
 }


### PR DESCRIPTION
- add alias provider for `us-east-1` because cloudfront requires the cert in `us-east-1`
- create a `retrieval.{app_domain}` certificate in `us-east-1`
- create cloudfront distribution for `retrieval.{app_domain}`

TODO: 
- [x] test cache behaviour
- [x] switch `retrieval.{app_domain}` CNAME to point to cloudfront distribution