### PR TITLE
Add /services/version.json endpoint

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -18,6 +18,7 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
   TF_VAR_ecs_task_key_retrieval_env_hmac_key: ${{ secrets.TF_VAR_ecs_task_key_retrieval_env_hmac_key }}
+  TF_VAR_ecs_task_key_retrieval_env_ecdsa_key: ${{ secrets.TF_VAR_ecs_task_key_retrieval_env_ecdsa_key }}
   TF_VAR_ecs_task_key_submission_env_key_claim_token: ${{ secrets.TF_VAR_ecs_task_key_submission_env_key_claim_token }}
   TF_VAR_rds_backend_db_password: ${{ secrets.TF_VAR_rds_backend_db_password }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 /.vscode
 config/terraform/*/.terraform/*
 config/terraform/*/terraform.tfstate*
-covidshield-server
+/server

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.vscode
 config/terraform/*/.terraform/*
 config/terraform/*/terraform.tfstate*
+covidshield-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN adduser \
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="${GOLDFLAGS}" -o covidshield-server ./cmd/${component}
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="${GOLDFLAGS}" -o server ./cmd/${component}
 
 ###
 # Step 2 - Build
@@ -39,9 +39,9 @@ WORKDIR /usr/local/bin
 # Import the user and group files from step 1
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
-COPY --from=builder --chown=${USER}:${USER} /go/src/github.com/CovidShield/server/covidshield-server /usr/local/bin/covidshield-server
+COPY --from=builder --chown=${USER}:${USER} /go/src/github.com/CovidShield/server/server /usr/local/bin/server
 
 USER ${USER}:${USER}
 
 # hadolint ignore=DL3025
-ENTRYPOINT ["covidshield-server"]
+ENTRYPOINT ["server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,47 @@
-# builder stage
+###
+# Step 1 - Compile
+###
 FROM golang:1.14-alpine AS builder
+
 ARG component=${component:-key-retrieval}
+ARG branch
+ARG revision
+
 ENV GO111MODULE=on
+ENV USER=covidshield
+ENV UID=10001
+ENV GOLDFLAGS="-X github.com/CovidShield/server/pkg/server.branch=${branch} -X github.com/CovidShield/server/pkg/server.revision=${revision}"
+
 WORKDIR /go/src/github.com/CovidShield/server
+
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    "${USER}"
+
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o ${component} ./cmd/${component}
 
-# target stage
-FROM alpine:3
-ARG component=${component:-key-retrieval}
-ENV component=${component}
-ARG APP_UID=${APP_UID:-2000}
-ARG APP_GID=${APP_GID:-2000}
-RUN addgroup -g ${APP_GID} -S ${component} && \
-    adduser -u ${APP_UID} -S ${component} -G ${component}
-COPY --from=builder --chown=${APP_UID}:${APP_GID} /go/src/github.com/CovidShield/server/${component} /usr/local/bin/${component}
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="${GOLDFLAGS}" -o covidshield-server ./cmd/${component}
 
-USER ${APP_UID}:${APP_GID}
+###
+# Step 2 - Build
+###
+FROM scratch
+
+ENV USER=covidshield
+
+WORKDIR /usr/local/bin
+
+# Import the user and group files from step 1
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder --chown=${USER}:${USER} /go/src/github.com/CovidShield/server/covidshield-server /usr/local/bin/covidshield-server
+
+USER ${USER}:${USER}
 
 # hadolint ignore=DL3025
-ENTRYPOINT "/usr/local/bin/${component}"
+ENTRYPOINT ["covidshield-server"]

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ GCFLAGS_DEBUG   := $(GCFLAGS) -N -l
 # You may need/want to set this to "bundle exec grpc_tools_ruby_protoc"
 GRPC_TOOLS_RUBY_PROTOC := grpc_tools_ruby_protoc
 
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+REVISION=`git rev-parse HEAD`
+GOLDFLAGS="-X $(MODULE)/pkg/server.branch=$(BRANCH) -X $(MODULE)/pkg/server.revision=$(REVISION)"
+
 default:  release
 release:  $(PROTO_GO) $(RELEASE_BUILDS)
 debug:    $(PROTO_GO) $(DEBUG_BUILDS)
@@ -33,12 +37,12 @@ proto:    $(PROTO_GO) $(PROTO_RB) $(RPC_RB)
 build/debug/%: $(GOFILES) $(PROTO_GO)
 	@mkdir -p "$(@D)"
 	@echo "     \x1b[1;34mgo build \x1b[0;1m(debug)\x1b[0m  $@"
-	@$(GO) build -trimpath -i -o "$@" -gcflags "$(GCFLAGS_DEBUG)" "$(MODULE)/cmd/$(@F)"
+	@$(GO) build -trimpath -i -ldflags=$(GOLDFLAGS) -o "$@" -gcflags "$(GCFLAGS_DEBUG)" "$(MODULE)/cmd/$(@F)"
 
 build/release/%: $(GOFILES) $(PROTO_GO)
 	@mkdir -p "$(@D)"
 	@echo "   \x1b[1;34mgo build \x1b[0;1m(release)\x1b[0m  $@"
-	@$(GO) build -trimpath -i -o "$@" -gcflags "$(GCFLAGS_RELEASE)" "$(MODULE)/cmd/$(@F)"
+	@$(GO) build -trimpath -i -ldflags=$(GOLDFLAGS) -o "$@" -gcflags "$(GCFLAGS_RELEASE)" "$(MODULE)/cmd/$(@F)"
 
 pkg/proto/%/proto.pb.go: proto/%.proto
 	@mkdir -p "$(@D)"

--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -45,6 +45,7 @@ data "template_file" "covidshield_key_retrieval_task" {
     awslogs-region        = var.region
     awslogs-stream-prefix = "ecs-${var.ecs_key_retrieval_name}"
     retrieve_hmac_key     = aws_secretsmanager_secret_version.key_retrieval_env_hmac_key.arn
+    ecdsa_key             = aws_secretsmanager_secret_version.key_retrieval_env_ecdsa_key.arn
     database_url          = aws_secretsmanager_secret_version.backend_database_url.arn
   }
 }

--- a/config/terraform/aws/iam.tf
+++ b/config/terraform/aws/iam.tf
@@ -23,6 +23,7 @@ data "aws_iam_policy_document" "covidshield_secrets_manager_key_retrieval" {
 
     resources = [
       aws_secretsmanager_secret.key_retrieval_env_hmac_key.arn,
+      aws_secretsmanager_secret.key_retrieval_env_ecdsa_key.arn,
       aws_secretsmanager_secret.backend_database_url.arn,
     ]
   }

--- a/config/terraform/aws/secrets.tf
+++ b/config/terraform/aws/secrets.tf
@@ -20,6 +20,15 @@ resource "aws_secretsmanager_secret_version" "key_retrieval_env_hmac_key" {
   secret_string = var.ecs_task_key_retrieval_env_hmac_key
 }
 
+resource "aws_secretsmanager_secret" "key_retrieval_env_ecdsa_key" {
+  name = "key-retrieval-env-ecdsa-key"
+}
+
+resource "aws_secretsmanager_secret_version" "key_retrieval_env_ecdsa_key" {
+  secret_id     = aws_secretsmanager_secret.key_retrieval_env_ecdsa_key.id
+  secret_string = var.ecs_task_key_retrieval_env_ecdsa_key
+}
+
 ###
 # AWS Secret Manager - Key Submission
 ###

--- a/config/terraform/aws/task-definitions/covidshield_key_retrieval.json
+++ b/config/terraform/aws/task-definitions/covidshield_key_retrieval.json
@@ -26,6 +26,10 @@
           "valueFrom": "${retrieve_hmac_key}"
         },
         {
+          "name": "ECDSA_KEY",
+          "valueFrom": "${ecdsa_key}"
+        },
+        {
           "name": "DATABASE_URL",
           "valueFrom": "${database_url}"
         }

--- a/config/terraform/aws/variables.auto.tfvars
+++ b/config/terraform/aws/variables.auto.tfvars
@@ -22,6 +22,8 @@ ecs_name = "CovidShield"
 ecs_key_retrieval_name = "KeyRetrieval"
 # Comes from a Github Secret
 # ecs_task_key_retrieval_env_hmac_key = ""
+# Comes from a Github Secret
+# ecs_task_key_retrieval_env_ecdsa_key = ""
 
 # Key Submission
 ecs_key_submission_name = "KeySubmission"

--- a/config/terraform/aws/variables.tf
+++ b/config/terraform/aws/variables.tf
@@ -41,6 +41,10 @@ variable "ecs_task_key_retrieval_env_hmac_key" {
   type = string
 }
 
+variable "ecs_task_key_retrieval_env_ecdsa_key" {
+  type = string
+}
+
 # Task Key Submission
 variable "ecs_key_submission_name" {
   type = string

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     build:
       context: .
       args:
+        branch: docker-compose
+        revision: docker-compose
         component: key-retrieval
     ports:
       - "8001:8001"
@@ -24,12 +26,15 @@ services:
       - mysql
     restart: always
     environment:
+      ECDSA_KEY: 30770201010420a6885a310b694b7bb4ba985459de1e79446dddcd1247c62ece925402b362a110a00a06082a8648ce3d030107a1440342000403eb64f714c4b4ed394331c26c31b7ce7156d00fb28982ad2679a87eaa1a3869802fbeb1d7ee28002762921929c3f7603672d535fcac3d24d57afbb4e2d97f5a
       DATABASE_URL: covidshield:covidshield@tcp(mysql)/covidshield
       RETRIEVE_HMAC_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   key-submission:
     build:
       context: .
       args:
+        branch: docker-compose
+        revision: docker-compose
         component: key-submission
     ports:
       - "8000:8000"


### PR DESCRIPTION
* Add `/services/version.json` endpoint to show what branch/revision the binary was built from 
* Add -ldflags to `go build` to populate branch and revision variables in server package
* Switch to using scratch containers
* Populate missing ECDSA_KEY in AWS Secret Manager and in Key Retrieval's task definition
* Add `ECDSA_KEY` as an environment variable to `key-retrieval` service in docker-compose.yml (closes #24, and duplicate fix in #25)

`TF_VAR_ecs_task_key_retrieval_env_ecdsa_key` has been added as a Github secret, and has been rotated so it's not the same value as the one specified in the supporting files (i.e. `dev.yml`, & `docker-compose.yml`).

TODO in another PR - modify the Terraform apply Github action to look for the latest revision

```
$ curl -s http://127.0.0.1:8001/services/version.json | jq
{
  "branch": "master",
  "revision": "10df36b225529230d827911ac869c302199e6116"
}
```