### PR TITLE
Fix database URL for test helper

### DIFF
--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -23,7 +23,7 @@ rescue KeyError
   raise('DB_HOST, DB_USER, and DB_PASS are all required environment variables')
 end
 
-DATABASE_URL = "#{DB_USER}#{DB_PASS}@tcp(#{DB_HOST})/#{DB_NAME}"
+DATABASE_URL = "#{DB_USER}:#{DB_PASS}@tcp(#{DB_HOST})/#{DB_NAME}"
 
 SUBMISSION_SERVER_ADDR = "127.0.0.1:18481"
 RETRIEVAL_SERVER_ADDR = "127.0.0.1:18482"


### PR DESCRIPTION
@burke figured this one out (thanks!): Puts a colon between the database user and password in the test helper.