### PR TITLE
Improve logic for 'Check For New Deployments' GH action job

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -82,30 +82,31 @@ jobs:
         GITHUB_SHA: ${{ github.sha }}
       run: |
         count=0
-        finished=0
+        kr_finished=0
+        ks_finished=0
 
-        while [ $count -le 60 ] && [ $finished -ne 2 ]
+        while [[ $count -le 180 && ($kr_finished -le 5 || $ks_finished -le 5) ]]
         do
           echo "Watching for new deployments - loop ${count}"
 
           kr_deployed_revision=$(curl -s https://retrieval.covidshield.app/services/version.json | jq -r .revision)
           if [ "${kr_deployed_revision}" == "${GITHUB_SHA}" ]; then
-            echo "Key Retrieval was successfully updated"
-            finished=$(( $finished + 1 ))
+            kr_finished=$(( $kr_finished + 1 ))
           fi
 
           ks_deployed_revision=$(curl -s https://submission.covidshield.app/services/version.json | jq -r .revision)
           if [ "${ks_deployed_revision}" == "${GITHUB_SHA}" ]; then
-            echo "Key Submission was successfully updated"
-            finished=$(( $finished + 1 ))
+            ks_finished=$(( $ks_finished + 1 ))
           fi
 
           count=$(( $count + 1 ))
           sleep 1
-          if [ $count -eq 60 ]; then
+          if [ $count -eq 180 ]; then
             echo "Deployment failed"
             exit 1
           fi
         done
 
+        echo "Key Retrieval was successfully updated - ${GITHUB_SHA}"
+        echo "Key Submission was successfully updated - ${GITHUB_SHA}"
         exit 0


### PR DESCRIPTION
Fixed an edge case where the loop wouldn't wait for both applications to be verified.