### PR TITLE
only forward Host header to cloudfront to allow caching

### DIFF
--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -27,7 +27,7 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
 
     forwarded_values {
       query_string = true
-      headers      = ["*"]
+      headers      = ["Host"]
 
       cookies {
         forward = "all"


### PR DESCRIPTION
As per the AWS Documentation [Headers and Distributions - Overview](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html#header-caching-web), forwarding all headers disables caching.