### PR TITLE
Perist keyclaim token that generated keys:

### DIFF
--- a/pkg/keyclaim/authenticator.go
+++ b/pkg/keyclaim/authenticator.go
@@ -29,6 +29,9 @@ func NewAuthenticator() Authenticator {
 		if len(parts) != assignmentParts {
 			panic("invalid KEY_CLAIM_TOKEN")
 		}
+		if len(parts[0]) > 63 {
+			panic("token too long")
+		}
 		if len(parts[1]) > 31 {
 			panic("region too long")
 		}

--- a/pkg/persistence/db.go
+++ b/pkg/persistence/db.go
@@ -32,7 +32,7 @@ type Conn interface {
 	// less than 14 days ago.
 	FetchKeysForPeriod(string, int32, int32) ([]*pb.TemporaryExposureKey, error)
 	StoreKeys(*[32]byte, []*pb.TemporaryExposureKey) error
-	NewKeyClaim(string) (string, error)
+	NewKeyClaim(string, string) (string, error)
 	ClaimKey(string, []byte) ([]byte, error)
 	PrivForPub([]byte) ([]byte, error)
 
@@ -108,7 +108,7 @@ func (c *conn) ClaimKey(oneTimeCode string, appPublicKey []byte) ([]byte, error)
 
 const maxOneTimeCode = 1e8
 
-func (c *conn) NewKeyClaim(region string) (string, error) {
+func (c *conn) NewKeyClaim(region, originator string) (string, error) {
 	var err error
 	var n *big.Int
 
@@ -125,7 +125,7 @@ func (c *conn) NewKeyClaim(region string) (string, error) {
 
 		oneTimeCode := fmt.Sprintf("%08d", n)
 
-		err = persistEncryptionKey(c.db, region, pub, priv, oneTimeCode)
+		err = persistEncryptionKey(c.db, region, originator, pub, priv, oneTimeCode)
 		if err == nil {
 			return oneTimeCode, nil
 		} else if strings.Contains(err.Error(), "Duplicate entry") {

--- a/pkg/persistence/migrator.go
+++ b/pkg/persistence/migrator.go
@@ -65,6 +65,14 @@ CREATE TABLE IF NOT EXISTS failed_key_claim_attempts (
 	INDEX (last_failure)
 )`,
 		},
+	}, {
+		id: "3",
+		statements: []string{
+			`ALTER TABLE diagnosis_keys  ADD COLUMN originator VARCHAR(64)`,
+			`ALTER TABLE encryption_keys ADD COLUMN originator VARCHAR(64)`,
+			`ALTER TABLE diagnosis_keys  ADD INDEX (originator)`,
+			`ALTER TABLE encryption_keys ADD INDEX (originator)`,
+		},
 	},
 }
 

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -76,14 +76,21 @@ module Helper
       )
     end
 
-    def new_valid_one_time_code
-      resp = @sub_conn.post do |req|
-        req.url('/new-key-claim')
-        req.headers['Authorization'] = 'Bearer first-token'
-      end
-      assert_response(resp, 200, 'text/plain; charset=utf-8')
-      resp.body.chomp
+    def encryption_originators
+      @dbconn.query("SELECT originator FROM encryption_keys").map(&:values).map(&:first)
     end
+
+    def diagnosis_originators
+      @dbconn.query("SELECT originator FROM encryption_keys").map(&:values).map(&:first)
+    end
+      def new_valid_one_time_code
+        resp = @sub_conn.post do |req|
+          req.url('/new-key-claim')
+          req.headers['Authorization'] = 'Bearer first-token'
+        end
+        assert_response(resp, 200, 'text/plain; charset=utf-8')
+        resp.body.chomp
+      end
 
     def new_valid_keyset
       otc = new_valid_one_time_code

--- a/test/new_key_claim_test.rb
+++ b/test/new_key_claim_test.rb
@@ -20,12 +20,14 @@ class NewKeyClaimTest < MiniTest::Test
       req.headers['Authorization'] = 'Bearer first-token'
     end
     assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
+    assert_equal(['first-token'], encryption_originators)
 
     resp = @sub_conn.post do |req|
       req.url('/new-key-claim')
       req.headers['Authorization'] = 'Bearer second-token'
     end
     assert_response(resp, 200, 'text/plain; charset=utf-8', body: /\A[0-9]{8}\n\z/m)
+    assert_equal(['first-token', 'second-token'], encryption_originators)
 
     %w[get patch delete put].each do |meth|
       resp = @sub_conn.send(meth, '/new-key-claim')

--- a/test/upload_test.rb
+++ b/test/upload_test.rb
@@ -19,6 +19,7 @@ class UploadTest < MiniTest::Test
     req = encrypted_request(dummy_payload, new_valid_keyset)
     resp = @sub_conn.post('/upload', req.to_proto)
     assert_result(resp, 200, :NONE)
+    assert_equal(['first-token'], diagnosis_originators)
 
     # timestamp almost too old
     req = encrypted_request(dummy_payload(timestamp: Time.at(Time.now.to_i - 59*60)), new_valid_keyset)


### PR DESCRIPTION
Keyclaim tokens will inevitably be compromised: It's probably necessary
to have this feature to be able to purge spammed tokens from compromised
sources.

Note what isn't implemented here: This is kind of calling out to be
turned into a richer model with authentication for keyclaim clients
stored in a database table, rather than simply in an environment
variable, and linking each key via a foreign key to those records,
rather than embedding the authentication token directly.

I *think* this is not necessary: the additional complexity would be an
operational burden, and though this means more data storage per key, I
think this is a tolerable tradeoff.