### PR TITLE
updated License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 COVID Shield Authors
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
You have incorrectly filled out the bottom of the Apache 2.0 License with information about the authors of this project. This section of the license is just describing how you apply the license, and is not meant to be filled out.