### PR TITLE
Handles zero keys inside upload payload

### DIFF
--- a/pkg/proto/covidshield/proto.pb.go
+++ b/pkg/proto/covidshield/proto.pb.go
@@ -114,6 +114,7 @@ const (
 	EncryptedUploadResponse_INVALID_KEY_DATA                      EncryptedUploadResponse_ErrorCode = 11
 	EncryptedUploadResponse_INVALID_ROLLING_START_INTERVAL_NUMBER EncryptedUploadResponse_ErrorCode = 12
 	EncryptedUploadResponse_INVALID_TRANSMISSION_RISK_LEVEL       EncryptedUploadResponse_ErrorCode = 13
+	EncryptedUploadResponse_NO_KEYS_IN_PAYLOAD										EncryptedUploadResponse_ErrorCode = 14
 )
 
 // Enum value maps for EncryptedUploadResponse_ErrorCode.

--- a/pkg/server/upload.go
+++ b/pkg/server/upload.go
@@ -122,6 +122,14 @@ func (s *uploadServlet) upload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(upload.GetKeys()) == 0 {
+		requestError(
+			ctx, w, err, "no keys provided",
+			http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_NO_KEYS_IN_PAYLOAD),
+		)
+		return
+	}
+
 	if len(upload.GetKeys()) > pb.MaxKeysInUpload {
 		requestError(
 			ctx, w, err, "too many keys provided",

--- a/proto/covidshield.proto
+++ b/proto/covidshield.proto
@@ -90,6 +90,7 @@ message EncryptedUploadResponse {
     INVALID_KEY_DATA = 11;
     INVALID_ROLLING_START_INTERVAL_NUMBER = 12;
     INVALID_TRANSMISSION_RISK_LEVEL = 13;
+    NO_KEYS_IN_PAYLOAD = 14;
   }
   required ErrorCode error = 1;
 }

--- a/test/lib/protocol/covidshield_pb.rb
+++ b/test/lib/protocol/covidshield_pb.rb
@@ -48,6 +48,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       value :INVALID_KEY_DATA, 11
       value :INVALID_ROLLING_START_INTERVAL_NUMBER, 12
       value :INVALID_TRANSMISSION_RISK_LEVEL, 13
+      value :NO_KEYS_IN_PAYLOAD, 14
     end
     add_message "covidshield.Upload" do
       required :timestamp, :message, 1, "google.protobuf.Timestamp"

--- a/test/upload_test.rb
+++ b/test/upload_test.rb
@@ -90,6 +90,11 @@ class UploadTest < MiniTest::Test
     resp = @sub_conn.post('/upload', req.to_proto)
     assert_result(resp, 200, :NONE)
 
+    # no keys
+    req = encrypted_request(dummy_payload(0), new_valid_keyset)
+    resp = @sub_conn.post('/upload', req.to_proto)
+    assert_result(resp, 400, :NO_KEYS_IN_PAYLOAD)
+
     # too many keys
     req = encrypted_request(dummy_payload(15), new_valid_keyset)
     resp = @sub_conn.post('/upload', req.to_proto)


### PR DESCRIPTION
When there are no keys in the upload payload, the following line of code will throw an unhandled exception because the `ints` array is empty:

https://github.com/CovidShield/server/blob/master/pkg/server/upload.go#L227

This PR adds a length check to see if the keys array is equal to 0. If it is, returns an error message.