### PR TITLE
Edit 'Platforms' heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ WAF](https://aws.amazon.com/waf/)), aggressively throttling users with 400 and 4
 
 - `key-retrieval` assumes it will be deployed behind a caching reverse proxy.
 
-###Platforms
+### Platforms
 
 We hope to provide reference implementations on AWS, GCP, and Azure via [Hashicorp Terraform](https://www.terraform.io/).
 


### PR DESCRIPTION
Noticed a small typo, padding the markdown heading with a space.