### PR TITLE
Specify a pre-release version (0.13.0) for now.

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -32,6 +32,8 @@ jobs:
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 0.13.0
 
     - name: Terraform Init
       run: terraform init
@@ -82,7 +84,7 @@ jobs:
         GITHUB_SHA: ${{ github.sha }}
         submission: submission.covidshield.app
         retrieval: retrieval.covidshield.app
-        
+
       run: |
         source ../../../bin/verify-deployment.sh
-        verify_deployments -c $GITHUB_SHA -e $submission -e $retrieval 
+        verify_deployments -c $GITHUB_SHA -e $submission -e $retrieval


### PR DESCRIPTION
Hashicorp merged a pull request on June 19th that prevents GitHub actions without a pinned version from using pre-release versions (i.e. 0.13.0 as of this writing):

https://github.com/hashicorp/setup-terraform/pull/19

However, this run appears to have used 0.13.0 before it was merged:

https://github.com/CovidShield/server/runs/786126855

I think we can still use the prerelease version if we specify it explicitly.