### PR TITLE
Revert "Specify a pre-release version (0.13.0) for now."

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -32,8 +32,6 @@ jobs:
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
-      with:
-        terraform_version: 0.13.0
 
     - name: Terraform Init
       run: terraform init
@@ -84,7 +82,7 @@ jobs:
         GITHUB_SHA: ${{ github.sha }}
         submission: submission.covidshield.app
         retrieval: retrieval.covidshield.app
-
+        
       run: |
         source ../../../bin/verify-deployment.sh
-        verify_deployments -c $GITHUB_SHA -e $submission -e $retrieval
+        verify_deployments -c $GITHUB_SHA -e $submission -e $retrieval 

--- a/config/terraform/aws/provider.tf
+++ b/config/terraform/aws/provider.tf
@@ -15,7 +15,7 @@ provider "github" {
 }
 
 terraform {
-  required_version = "> 0.12.0"
+  required_version = "~> 0.12.0"
 }
 
 terraform {


### PR DESCRIPTION
Well, that didn't work. I'm going to see if I can fix the state manually and fall back to `tf destroy` if I have to.