### PR TITLE
Remove post-dating of keys

### DIFF
--- a/pkg/persistence/queries.go
+++ b/pkg/persistence/queries.go
@@ -210,22 +210,6 @@ func diagnosisKeysForDateNumber(db *sql.DB, region string, dateNumber uint32, cu
 	)
 }
 
-func postDateKeyIfNecessary(hourOfSubmission uint32, key *pb.TemporaryExposureKey) uint32 {
-	// ENIntervalNumber at which the key became inactive
-	keyEnd := key.GetRollingStartIntervalNumber() + key.GetRollingPeriod()
-
-	// ENIntervalNumber at which we can safely serve the key
-	canServeAt := keyEnd + (144/24)*2
-
-	// interval to hour
-	minBoundForHour := uint32(canServeAt / 6)
-	if minBoundForHour > hourOfSubmission {
-		log(nil, nil).WithField("distance", minBoundForHour-hourOfSubmission).Info("post-dating key")
-		return minBoundForHour
-	}
-	return hourOfSubmission
-}
-
 func registerDiagnosisKeys(db *sql.DB, appPubKey *[32]byte, keys []*pb.TemporaryExposureKey) error {
 	tx, err := db.Begin()
 	if err != nil {
@@ -258,9 +242,7 @@ func registerDiagnosisKeys(db *sql.DB, appPubKey *[32]byte, keys []*pb.Temporary
 	var keysInserted int64
 
 	for _, key := range keys {
-		hourForKey := postDateKeyIfNecessary(hourOfSubmission, key)
-
-		result, err := s.Exec(region, originator, key.GetKeyData(), key.GetRollingStartIntervalNumber(), key.GetRollingPeriod(), key.GetTransmissionRiskLevel(), hourForKey)
+		result, err := s.Exec(region, originator, key.GetKeyData(), key.GetRollingStartIntervalNumber(), key.GetRollingPeriod(), key.GetTransmissionRiskLevel(), hourOfSubmission)
 		if err != nil {
 			if err := tx.Rollback(); err != nil {
 				return err

--- a/pkg/timemath/timemath.go
+++ b/pkg/timemath/timemath.go
@@ -9,7 +9,6 @@ import (
 const (
 	SecondsInHour  = 3600
 	SecondsInDay   = 86400
-	HoursPerPeriod = 6
 	HoursInDay     = 24
 )
 


### PR DESCRIPTION
Now that we're downloading keys every 24h, we shouldn't need to post-date keys, especially since it might bump them an entire day ahead.